### PR TITLE
docs(readme): add a single line to To create the symbolic link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,12 @@ git remote add origin https://github.com/<your-github-username>/<your-repo-name>
    composer install
    ```
 
-5. Generate app key and jwt secret key from the following commands:
+5. Generate app key and JWT secret key and create a symbolic link. Run the following commands one after another:
 
    ```bash
    php artisan key:generate
    php artisan jwt:secret
+   php artisan storage:link
    ```
 
 6. Run migrations and seeders to generate mock data to get the application ready:


### PR DESCRIPTION
This adds a missing line to the README for creating the symbolic link
I forgot to include this in the previous PR.